### PR TITLE
[FEAT] Add GET payment status endpoint

### DIFF
--- a/src/config/modules/payment.module.ts
+++ b/src/config/modules/payment.module.ts
@@ -1,7 +1,9 @@
 import { PrismaService } from '@/config/prisma.config';
 import { OrderWriterServicePort } from '@/core/interactor/port/order/order-writer-service.port';
+import { PaymentReaderServicePort } from '@/core/interactor/port/payment/payment-reader-service.port';
 import { PaymentWriterServicePort } from '@/core/interactor/port/payment/payment-writer-service.port';
 import { OrderWriterService } from '@/core/interactor/services/order/order-writer.service';
+import { PaymentReaderService } from '@/core/interactor/services/payment/payment-reader.service';
 import { PaymentWriterService } from '@/core/interactor/services/payment/payment-writer.service';
 import { IOrderRepository } from '@/core/repository/order/order.respository';
 import { IPaymentRepository } from '@/core/repository/payment/payment.repository';
@@ -17,8 +19,18 @@ import { Module } from '@nestjs/common';
     PrismaService,
     {
       provide: PaymentWriterServicePort,
-      useFactory: (paymentRepository: IPaymentRepository, orderWriterService: OrderWriterServicePort) => {
+      useFactory: (
+        paymentRepository: IPaymentRepository,
+        orderWriterService: OrderWriterServicePort,
+      ) => {
         return new PaymentWriterService(paymentRepository, orderWriterService);
+      },
+      inject: [IPaymentRepository, OrderWriterServicePort],
+    },
+    {
+      provide: PaymentReaderServicePort,
+      useFactory: (paymentRepository: IPaymentRepository) => {
+        return new PaymentReaderService(paymentRepository);
       },
       inject: [IPaymentRepository, OrderWriterServicePort],
     },
@@ -39,4 +51,4 @@ import { Module } from '@nestjs/common';
     },
   ],
 })
-export class PaymentModule { }
+export class PaymentModule {}

--- a/src/core/interactor/port/payment/payment-reader-service.port.ts
+++ b/src/core/interactor/port/payment/payment-reader-service.port.ts
@@ -1,6 +1,5 @@
 import { Payment } from '@/core/domain/payment/payment.entity';
 
-export abstract class IPaymentRepository {
-  abstract create(payment: Payment): Promise<Payment>;
+export abstract class PaymentReaderServicePort {
   abstract findById(id: string): Promise<Payment>;
 }

--- a/src/core/interactor/services/payment/payment-reader.service.ts
+++ b/src/core/interactor/services/payment/payment-reader.service.ts
@@ -1,0 +1,14 @@
+import { NotFoundException } from '@/core/exceptions/custom-exceptions/not-found.exception';
+import { IPaymentRepository } from '@/core/repository/payment/payment.repository';
+
+export class PaymentReaderService {
+  constructor(private readonly paymentRepository: IPaymentRepository) {}
+
+  async findById(id: string) {
+    try {
+      return await this.paymentRepository.findById(id);
+    } catch (error) {
+      throw new NotFoundException({ description: 'Payment not found' });
+    }
+  }
+}

--- a/src/datasource/adapter/payment/payment-postgres.adapter.ts
+++ b/src/datasource/adapter/payment/payment-postgres.adapter.ts
@@ -15,4 +15,12 @@ export class PaymentPostgresAdapter implements IPaymentRepository {
       },
     });
   }
+
+  async findById(id: string): Promise<Payment> {
+    return await this.prisma.payment.findUniqueOrThrow({
+      where: {
+        id,
+      },
+    });
+  }
 }

--- a/src/transport/constant/payment.constant.ts
+++ b/src/transport/constant/payment.constant.ts
@@ -4,6 +4,10 @@ export const PAYMENT = {
       SUMMARY: 'Creates a checkout payment register',
       DESC: 'Creates a checkout payment register attached to an order in database',
     },
+    GET_BY_ID: {
+      SUMMARY: 'Gets payment status by identifier',
+      DESC: 'Fetches payment status from database register by identifier',
+    },
     PAYMENT: {
       ID: {
         DESC: 'Payment identifier in database',
@@ -16,6 +20,10 @@ export const PAYMENT = {
       METHOD: {
         DESC: 'Category in which the payment is registered',
         EXAMPLE: 'Credit Card',
+      },
+      STATUS: {
+        DESC: 'Status in which the payment is',
+        EXAMPLE: 'APROVADO',
       },
     },
   },

--- a/src/transport/controller/payment.controller.ts
+++ b/src/transport/controller/payment.controller.ts
@@ -1,21 +1,30 @@
-import { Body, Controller, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpStatus, Param, Post } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-import { InternalServerErrorException } from '@/core/exceptions/custom-exceptions/internal-server-error.exception';
 import { Payment } from '@/core/domain/payment/payment.entity';
+import { InternalServerErrorException } from '@/core/exceptions/custom-exceptions/internal-server-error.exception';
+import { NotFoundException } from '@/core/exceptions/custom-exceptions/not-found.exception';
+import { PaymentReaderServicePort } from '@/core/interactor/port/payment/payment-reader-service.port';
 import { PaymentWriterServicePort } from '@/core/interactor/port/payment/payment-writer-service.port';
 import { API_RESPONSE } from '@/transport/constant/api-response.constant';
 import { PAYMENT } from '@/transport/constant/payment.constant';
 import { CreatePaymentDto, toDomain } from '@/transport/dto/payment/request/payment.dto';
+import {
+  GetPaymentStatusResponseDto,
+  toDTO,
+} from '@/transport/dto/payment/response/get-payment-status.dto';
 
-
-const { CREATE } = PAYMENT.API_PROPERTY;
-const { CREATED_DESC, INTERNAL_SERVER_EXCEPTION_DESC } = API_RESPONSE;
+const { CREATE, GET_BY_ID } = PAYMENT.API_PROPERTY;
+const { CREATED_DESC, OK_DESC, INTERNAL_SERVER_EXCEPTION_DESC, NOT_FOUND_DESC } =
+  API_RESPONSE;
 
 @Controller('payments')
 @ApiTags('payments')
 export class PaymentController {
-  constructor(private readonly paymentService: PaymentWriterServicePort) { }
+  constructor(
+    private readonly paymentWriterService: PaymentWriterServicePort,
+    private readonly paymentReaderService: PaymentReaderServicePort,
+  ) {}
 
   @Post()
   @ApiOperation({ summary: CREATE.SUMMARY, description: CREATE.DESC })
@@ -23,8 +32,36 @@ export class PaymentController {
     status: HttpStatus.CREATED,
     description: CREATED_DESC,
   })
-  @ApiResponse({ status: HttpStatus.INTERNAL_SERVER_ERROR, description: INTERNAL_SERVER_EXCEPTION_DESC, type: () => InternalServerErrorException })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: INTERNAL_SERVER_EXCEPTION_DESC,
+    type: () => InternalServerErrorException,
+  })
   async create(@Body() createPaymentDto: CreatePaymentDto): Promise<Payment> {
-    return this.paymentService.create(toDomain(createPaymentDto), createPaymentDto.orderId);
+    return this.paymentWriterService.create(
+      toDomain(createPaymentDto),
+      createPaymentDto.orderId,
+    );
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: GET_BY_ID.SUMMARY, description: GET_BY_ID.DESC })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: OK_DESC,
+    type: () => GetPaymentStatusResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: NOT_FOUND_DESC,
+    type: () => NotFoundException,
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: INTERNAL_SERVER_EXCEPTION_DESC,
+    type: () => InternalServerErrorException,
+  })
+  async getStatusById(@Param('id') id: string): Promise<any> {
+    return toDTO(await this.paymentReaderService.findById(id));
   }
 }

--- a/src/transport/dto/payment/response/get-payment-status.dto.ts
+++ b/src/transport/dto/payment/response/get-payment-status.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Payment } from '@/core/domain/payment/payment.entity';
+import { PAYMENT } from '@/transport/constant/payment.constant';
+
+const { STATUS } = PAYMENT.API_PROPERTY.PAYMENT;
+
+export class GetPaymentStatusResponseDto {
+  @ApiProperty({
+    description: STATUS.DESC,
+    example: STATUS.EXAMPLE,
+  })
+  status: string;
+
+  constructor(id?: string) {
+    this.status = id ? 'APROVADO' : null;
+  }
+}
+
+export const toDTO = (payment: Payment): GetPaymentStatusResponseDto => {
+  return new GetPaymentStatusResponseDto(payment.id);
+};

--- a/test/payment/payment-reader.service.spec.ts
+++ b/test/payment/payment-reader.service.spec.ts
@@ -1,0 +1,37 @@
+import { NotFoundException } from '@/core/exceptions/custom-exceptions/not-found.exception';
+import { PaymentReaderService } from '@/core/interactor/services/payment/payment-reader.service';
+import { IPaymentRepository } from '@/core/repository/payment/payment.repository';
+import { randomUUID } from 'crypto';
+
+describe('PaymentReaderService', () => {
+  let paymentRepository: IPaymentRepository = { create: jest.fn(), findById: jest.fn() };
+  let service: PaymentReaderService = new PaymentReaderService(paymentRepository);
+
+  const paymentMock = {
+    id: '1',
+    value: 100,
+    method: 'Credit Card',
+    createdAt: new Date(),
+  };
+
+  describe('findById', () => {
+    it('should return payment status', async () => {
+      jest.spyOn(paymentRepository, 'findById').mockResolvedValue(paymentMock);
+
+      expect(await service.findById('1')).toBe(paymentMock);
+      expect(paymentRepository.findById).toHaveBeenCalled();
+    });
+
+    it('should throw an error if payment is not registered in database', async () => {
+      jest.spyOn(paymentRepository, 'findById').mockRejectedValueOnce(new Error());
+
+      try {
+        return await service.findById(randomUUID());
+      } catch (error) {
+        expect(error).toEqual(
+          new NotFoundException({ description: 'Payment not found' }),
+        );
+      }
+    });
+  });
+});

--- a/test/payment/payment-writer.service.spec.ts
+++ b/test/payment/payment-writer.service.spec.ts
@@ -1,4 +1,3 @@
-import { InternalServerErrorException } from '@/core/exceptions/custom-exceptions/internal-server-error.exception';
 import { Order } from '@/core/domain/order/order.entity';
 import { StatusEnum } from '@/core/domain/order/status.entity';
 import { Payment } from '@/core/domain/payment/payment.entity';
@@ -17,12 +16,20 @@ describe('PaymentService', () => {
       create: jest.fn((payment) =>
         Promise.resolve({ ...payment, id: 'some-id', createdAt: new Date() }),
       ),
+      findById: jest.fn(),
     };
 
     orderWriterService = {
       create: jest.fn((order) => Promise.resolve({ ...order, id: '1' })),
       update: jest.fn((order) =>
-        Promise.resolve({ id: order.id, status: order.status, orderCode: 1, clientId: '1', paymentId: 'some-id', createdAt: new Date() }),
+        Promise.resolve({
+          id: order.id,
+          status: order.status,
+          orderCode: 1,
+          clientId: '1',
+          paymentId: 'some-id',
+          createdAt: new Date(),
+        }),
       ),
     };
 
@@ -33,7 +40,7 @@ describe('PaymentService', () => {
     const paymentDto: CreatePaymentDto = {
       value: 100,
       method: 'Credit Card',
-      orderId: '1'
+      orderId: '1',
     };
 
     const expectedPayment: Payment = {
@@ -47,8 +54,8 @@ describe('PaymentService', () => {
       status: StatusEnum.RECEIVED,
       orderCode: 1,
       clientId: '1',
-      paymentId: expectedPayment.id
-    }
+      paymentId: expectedPayment.id,
+    };
 
     jest.spyOn(paymentRepository, 'create').mockResolvedValue(expectedPayment);
     jest.spyOn(orderWriterService, 'update').mockResolvedValue(expectedOrder);
@@ -62,12 +69,14 @@ describe('PaymentService', () => {
     const paymentDto: CreatePaymentDto = {
       value: 100,
       method: 'Credit Card',
-      orderId: '1'
+      orderId: '1',
     };
 
     jest
       .spyOn(paymentRepository, 'create')
       .mockRejectedValue(new Error('Failed to create payment'));
-    await expect(service.create(toDomain(paymentDto), paymentDto.orderId)).rejects.toThrow(Error);
+    await expect(
+      service.create(toDomain(paymentDto), paymentDto.orderId),
+    ).rejects.toThrow(Error);
   });
 });


### PR DESCRIPTION
- Implemented GET /:id endpoint that returns payment status as specified in notion board
- Added payment reader interface and service
- Added unit tests for payment reader service


When reviewing this CR, have in mind that we do not have a status column in payment table, **at this point**, when checkout is executed a payment is created and the order is 'finished/delivered' so until the integration with Mercado Pago is implemented this is a workaround.
